### PR TITLE
support mixed http-01 and dns-01 challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ and read your private account key and CSR.
 python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /var/www/challenges/ > ./signed_chain.crt
 ```
 
+If you are requesting a wildcard certificate (`*.yoursite.com`), then Let's
+Encrypt will require you to prove ownership of DNS via the dns-01 challenge. In
+this case, additionally provide the `--dns-01-script` argument when calling
+`acme_tiny.py`. It must contain the path to a script which can add/remove a TXT
+record `_acme-challenge.yoursite.com` on your DNS server. The script must have
+the following signature: `dns_script (--add|--remove) --domain DOMAIN
+-txtrecord TXTRECORD`. Example: `dns_script --add --domain yoursite.com
+--txtrecord qLSh85v2W8MFIUWrCbx27FZM_LIfq6qvK5ulrowoxAA`. Your script should
+sleep after adding the TXT record for however long it requires for the DNS
+changes to propagate. For example 15 minutes should be safe in most cases.
+
 ### Step 5: Install the certificate
 
 The signed https certificate chain that is output by this script can be used along

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.INFO)
 
-def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check=False, directory_url=DEFAULT_DIRECTORY_URL, contact=None, challenge_type="http", challenge_script=None):
+def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check=False, directory_url=DEFAULT_DIRECTORY_URL, contact=None, dns_script=None):
     directory, acct_headers, alg, jwk = None, None, None, None # global variables
 
     # helper functions - base64 encode for jose spec
@@ -69,12 +69,6 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
             time.sleep(0 if result is None else 2)
             result, _, _ = _send_signed_request(url, None, err_msg)
         return result
-
-    if challenge_type not in ("http", "dns"):
-        raise ValueError("Unsupported challenge type: {0}".format(challenge_type))
-
-    if challenge_type == "dns" and challenge_script is None:
-        raise ValueError("Challenge script is required for dns challenge")
 
     # parse account key to get public key
     log.info("Parsing account key...")
@@ -133,47 +127,46 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
         domain = authorization['identifier']['value']
         log.info("Verifying {0}...".format(domain))
 
-        challenge = None
-        wellknown_path = None
-        if challenge_type == "http":
-            # find the http-01 challenge and write the challenge file
-            challenge = [c for c in authorization['challenges'] if c['type'] == "http-01"][0]
-            token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge['token'])
-            keyauthorization = "{0}.{1}".format(token, thumbprint)
-            wellknown_path = os.path.join(acme_dir, token)
+        # prefer the http-01 challenge but fall back to dns-01
+        challenge = sorted(authorization['challenges'], key=lambda a: {"http-01": 0, "dns-01": 1}.get(a["type"], 100))[0]
+        token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge['token'])
+        keyauthorization = "{0}.{1}".format(token, thumbprint)
+        wellknown_path = os.path.join(acme_dir, token)
+        txtrecord = _b64(hashlib.sha256(keyauthorization).digest())
+
+        # solve challenge and self check it
+        if challenge["type"] == "http-01":
             with open(wellknown_path, "w") as wellknown_file:
                 wellknown_file.write(keyauthorization)
-
-            # check that the file is in place
             try:
                 wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
-                assert(disable_check or _do_request(wellknown_url)[0] == keyauthorization)
+                assert (disable_check or _do_request(wellknown_url)[0] == keyauthorization)
             except (AssertionError, ValueError) as e:
-                os.remove(wellknown_path)
                 raise ValueError("Wrote file to {0}, but couldn't download {1}: {2}".format(wellknown_path, wellknown_url, e))
-        elif challenge_type == "dns":
-            challenge = [c for c in authorization['challenges'] if c['type'] == "dns-01"][0]
-            token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge['token'])
-            keyauthorization = "{0}.{1}".format(token, thumbprint)
-            txtrecord = _b64(hashlib.sha256(keyauthorization).digest())
-            subprocess.call([challenge_script, "--add", "--domain", domain, txtrecord])
+        elif challenge["type"] == "dns-01":
+            if dns_script is None or dns_script == "":
+                raise ValueError("Missing argument --dns-01-script")
+            _cmd([dns_script, "--add", "--domain", domain.lstrip("*."), "--txtrecord", txtrecord], err_msg="dns-01 script error while adding")
             try:
-                subprocess.call(["host", "-t", "TXT", "_acme-challenge.{0}".format(domain)])
-                assert(disable_check or True) # TODO
-            except AssertionError:
-                subprocess.call([challenge_script, "--remove", "--domain", domain, txtrecord])
+                assert (disable_check or _cmd(["host", "-t", "TXT", "_acme-challenge.{0}".format(domain.lstrip("*."))]).find(txtrecord.encode("ascii")) != -1)
+            except (AssertionError, IOError) as e:
+                _cmd([dns_script, "--remove", "--domain", domain.lstrip("*."), "--txtrecord", txtrecord], err_msg="dns-01 script error while removing")
                 raise ValueError("Set up the DNS challenge, but couldn't verify: {0}".format(e))
+        else:
+            raise ValueError("Unsupported challenge type {0}".format(challenge["type"]))
 
         # say the challenge is done
         _send_signed_request(challenge['url'], {}, "Error submitting challenges: {0}".format(domain))
         authorization = _poll_until_not(auth_url, ["pending"], "Error checking challenge status for {0}".format(domain))
         if authorization['status'] != "valid":
             raise ValueError("Challenge did not pass for {0}: {1}".format(domain, authorization))
-        if challenge_type == "http":
-            os.remove(wellknown_path)
-        elif challenge_type == "dns":
-            subprocess.call([challenge_script, "--remove", "--domain", domain, txtrecord])
         log.info("{0} verified!".format(domain))
+
+        # clean up after challenge
+        if challenge["type"] == "http-01":
+            os.remove(wellknown_path)
+        elif challenge["type"] == "dns-01":
+            _cmd([dns_script, "--remove", "--domain", domain.lstrip("*."), "--txtrecord", txtrecord], err_msg="dns-01 script error while removing")
 
     # finalize the order with the csr
     log.info("Signing certificate...")
@@ -213,12 +206,11 @@ def main(argv=None):
     parser.add_argument("--directory-url", default=DEFAULT_DIRECTORY_URL, help="certificate authority directory url, default is Let's Encrypt")
     parser.add_argument("--ca", default=DEFAULT_CA, help="DEPRECATED! USE --directory-url INSTEAD!")
     parser.add_argument("--contact", metavar="CONTACT", default=None, nargs="*", help="Contact details (e.g. mailto:aaa@bbb.com) for your account-key")
-    parser.add_argument("--challenge-type", required=False, default="http", help="type of ACME challenge, supported: http, dns")
-    parser.add_argument("--challenge-script", required=False, default=None, help="script to set up challenge on the server (required for dns challenge)")
+    parser.add_argument("--dns-01-script", required=False, default=None, help="path to script that updates your DNS server for the dns-01 challenge")
 
     args = parser.parse_args(argv)
     LOGGER.setLevel(args.quiet or LOGGER.level)
-    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, challenge_type=args.challenge_type, challenge_script=args.challenge_script)
+    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, dns_script=args.dns_01_script)
     sys.stdout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover


### PR DESCRIPTION
This adds support for certificates that requires both the dns-01 and http-01 challenge. I think this is fairly common, when you want a cert that works for both `*.yoursite.com` as well as just `yoursite.com`. As far as I can tell, it's Let's Encrypt's ACME server that decides whether to give us a dns-01 challenge, or http-01 challenge. In the case of `*.yoursite.com,yoursite.com`, from what I observed it will first require a dns-01 challenge for `*.yoursite.com`, and then a http-01 challenge for `yoursite.com`.

Also tried to reduce the line count a little bit by pulling back out the `keyauthorization = ...`-lines that are common for both http-01 and dns-01. This gets the line count down from 225 to 217. Still quite a bit higher than diafygi's 198, and he has stated that one of the project goals is to stay below 200 lines. So this might be a show stopper.

Suggesting to rename `--challenge-script` to `--dns-01-script`, so its purpose is clearer, since it's only ever used for the dns-01 challenge. If a new challenges comes up in the future, the script calling signature will probably need to be different anyway.

Added `--txtrecord` to the signature of the script being called, for consistency.

Switched to using `_cmd` instead of `subprocess.call`, to try to better fit into diafygi's code style.

Added some instructions to README.md.